### PR TITLE
Revert "chore: Update `Cargo.toml`"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ pedantic = "warn"
 
 [lints.rust]
 missing_debug_implementations = "deny"
-missing_docs = "deny"
 rust_2018_idioms = { level = "warn", priority = -1 }
 unsafe_code = "forbid"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //! [RON]: https://github.com/ron-rs/ron
 
 #![doc(html_root_url = "https://docs.rs/ron-wasm/0.1.0/")]
+// Lint levels of rustc.
+#![deny(missing_docs)]
 
 mod parse;
 mod stringify;


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
This reverts commit 793f3255f28de4d399614c5328a256df31834ecb.

Because the test fails in Rust 1.83.0.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/ron-wasm/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/ron-wasm/blob/develop/CODE_OF_CONDUCT.md
